### PR TITLE
프로듀서, 보컬 프로필과 포트폴리오 조회 기능 완성

### DIFF
--- a/src/domain/mypage/controller/MypageController.ts
+++ b/src/domain/mypage/controller/MypageController.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { rm, sc } from '../../../global/constants';
+import { success } from '../../../global/constants/response';
+import { InformationGetDTO } from '../interfaces';
+import MypageService from '../service/MypageService';
+
+const getUserInfo = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { page, limit } = req.query;
+        const infoDTO: InformationGetDTO = req.body;
+
+        const result = await MypageService.getUserInfo(infoDTO, Number(page), Number(limit));
+        return res.status(sc.OK).send(success(sc.CREATED, rm.GET_USER_INFORMATION_SUCCESS, result));
+    } catch (error) {
+        return next(error);
+    }
+};
+
+const MypageController = {
+    getUserInfo,
+};
+
+export default MypageController;

--- a/src/domain/mypage/interfaces/InformationGetDTO.ts
+++ b/src/domain/mypage/interfaces/InformationGetDTO.ts
@@ -1,0 +1,4 @@
+export default interface InformationGetDTO {
+    tableName: string;
+    userId: string;
+};

--- a/src/domain/mypage/interfaces/index.ts
+++ b/src/domain/mypage/interfaces/index.ts
@@ -1,3 +1,4 @@
+export { default as InformationGetDTO } from './InformationGetDTO'; 
 export { default as PortfolioCreateDTO} from './PortfolioCreateDTO';
 export { default as ProducerPortfolioCreateReturnDTO } from './ProducerPortfolioCreateReturnDTO';
 export { default as VocalPortfolioCreateReturnDTO } from './VocalPortfolioCreateReturnDTO';

--- a/src/domain/mypage/router/MypageRouter.ts
+++ b/src/domain/mypage/router/MypageRouter.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { authJWT, checkPaginationValue } from '../../../global/middlewares';
+import MypageController from '../controller/MypageController';
+
+const router: Router = Router();
+
+router.get('/',
+            checkPaginationValue,
+            authJWT,
+            MypageController.getUserInfo);
+                
+export default router;

--- a/src/domain/mypage/router/index.ts
+++ b/src/domain/mypage/router/index.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
+import mypageRouter from './MypageRouter';
 import producerRouter from './ProducerRouter';
 import vocalRouter from './VocalRouter';
 
 const router: Router = Router();
 
+router.use('/', mypageRouter);
 router.use('/producer', producerRouter);
 router.use('/vocal', vocalRouter);
 

--- a/src/domain/mypage/service/MypageService.ts
+++ b/src/domain/mypage/service/MypageService.ts
@@ -1,0 +1,15 @@
+import { InformationGetDTO } from '../interfaces';
+
+const getUserInfo = async (infoDTO: InformationGetDTO, page: number, limit: number) => {
+    try {
+        
+    } catch (error) {
+        throw error;
+    }
+};
+
+const MypageService = {
+    getUserInfo,
+};
+
+export default MypageService;

--- a/src/domain/profile/controller/ProducerController.ts
+++ b/src/domain/profile/controller/ProducerController.ts
@@ -2,9 +2,22 @@ import { Request, Response, NextFunction } from 'express';
 import { rm, sc } from '../../../global/constants';
 import { success } from '../../../global/constants/response';
 import getLocation from '../../../global/modules/file/multer/key';
-import { ProducerProfileUpdateDTO } from '../interfaces';
+import { ProducerProfileGetDTO, ProducerProfileUpdateDTO } from '../interfaces';
 import ProducerService from '../service/ProducerService';
 
+const getProducerProfile = async(req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { producerId } = req.params;
+        const { page, limit } = req.query;
+        const profileDTO: ProducerProfileGetDTO = req.body;
+
+        const result = await ProducerService.getProducerProfile(profileDTO, Number(producerId), Number(page), Number(limit));
+
+        return res.status(sc.OK).send(success(sc.OK, rm.GET_PRODUCER_PROFILE_SUCCESS, result));
+    } catch (error) {
+        return next(error);
+    }
+};
 const updateProducerProfile = async(req: Request, res: Response, next: NextFunction) => {
     try {
         const imageFileKey: Express.MulterS3.File = req.file as Express.MulterS3.File;
@@ -22,6 +35,7 @@ const updateProducerProfile = async(req: Request, res: Response, next: NextFunct
 };
 
 const ProducerController = {
+    getProducerProfile,
     updateProducerProfile,
 };
 

--- a/src/domain/profile/controller/ProducerController.ts
+++ b/src/domain/profile/controller/ProducerController.ts
@@ -18,6 +18,7 @@ const getProducerProfile = async(req: Request, res: Response, next: NextFunction
         return next(error);
     }
 };
+
 const updateProducerProfile = async(req: Request, res: Response, next: NextFunction) => {
     try {
         const imageFileKey: Express.MulterS3.File = req.file as Express.MulterS3.File;

--- a/src/domain/profile/controller/VocalController.ts
+++ b/src/domain/profile/controller/VocalController.ts
@@ -2,8 +2,22 @@ import { Request, Response, NextFunction } from 'express';
 import { rm, sc } from '../../../global/constants';
 import { success } from '../../../global/constants/response';
 import getLocation from '../../../global/modules/file/multer/key';
-import { VocalProfileUpdateDTO } from '../interfaces';
+import { VocalProfileGetDTO, VocalProfileUpdateDTO } from '../interfaces';
 import VocalService from '../service/VocalService';
+
+const getVocalProfile = async(req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { vocalId } = req.params;
+        const { page, limit } = req.query;
+        const profileDTO: VocalProfileGetDTO = req.body;
+
+        const result = await VocalService.getVocalProfile(profileDTO, Number(vocalId), Number(page), Number(limit));
+
+        return res.status(sc.OK).send(success(sc.OK, rm.GET_VOCAL_PROFILE_SUCCESS, result));
+    } catch (error) {
+        return next(error);
+    }
+};
 
 const updateVocalProfile = async(req: Request, res: Response, next: NextFunction) => {
     try {
@@ -22,6 +36,7 @@ const updateVocalProfile = async(req: Request, res: Response, next: NextFunction
 };
 
 const VocalController = {
+    getVocalProfile,
     updateVocalProfile,
 };
 

--- a/src/domain/profile/interfaces/PortfolioDTO.ts
+++ b/src/domain/profile/interfaces/PortfolioDTO.ts
@@ -1,0 +1,10 @@
+export default interface PortfolioDTO {
+    id: number;
+    jacketImage: string;
+    beatWavFile: string;
+    title: string;
+    content: string;
+    keyword: string[];
+    category: string;
+    wavFileLength: number;
+};

--- a/src/domain/profile/interfaces/ProducerProfileDTO.ts
+++ b/src/domain/profile/interfaces/ProducerProfileDTO.ts
@@ -1,4 +1,4 @@
-export default interface ProfileDTO {
+export default interface ProducerProfileDTO {
     id: number;
     profileImage: string;
     name: string;

--- a/src/domain/profile/interfaces/ProducerProfileGetDTO.ts
+++ b/src/domain/profile/interfaces/ProducerProfileGetDTO.ts
@@ -1,0 +1,4 @@
+export default interface ProducerProfileGetDTO {
+    tableName: string;
+    userId: string;
+};

--- a/src/domain/profile/interfaces/ProducerProfileGetReturnDTO.ts
+++ b/src/domain/profile/interfaces/ProducerProfileGetReturnDTO.ts
@@ -1,7 +1,7 @@
 import PortfolioDTO from './PortfolioDTO';
-import ProfileDTO from './ProfileDTO';
+import ProfileDTO from './ProducerProfileDTO';
 
-export default interface ProducerProfileGetDTO {
+export default interface ProducerProfileGetReturnDTO {
     whoamI: string;
     isMe: boolean;
     producerProfile: ProfileDTO;

--- a/src/domain/profile/interfaces/ProducerProfileGetReturnDTO.ts
+++ b/src/domain/profile/interfaces/ProducerProfileGetReturnDTO.ts
@@ -1,0 +1,9 @@
+import PortfolioDTO from './PortfolioDTO';
+import ProfileDTO from './ProfileDTO';
+
+export default interface ProducerProfileGetDTO {
+    whoamI: string;
+    isMe: boolean;
+    producerProfile: ProfileDTO;
+    producerPortfolio: PortfolioDTO[];
+};

--- a/src/domain/profile/interfaces/ProfileDTO.ts
+++ b/src/domain/profile/interfaces/ProfileDTO.ts
@@ -1,0 +1,9 @@
+export default interface ProfileDTO {
+    id: number;
+    profileImage: string;
+    name: string;
+    contact: string;
+    category: string[];
+    keyword: string[];
+    introduce: string;
+};

--- a/src/domain/profile/interfaces/VocalProfileDTO.ts
+++ b/src/domain/profile/interfaces/VocalProfileDTO.ts
@@ -1,0 +1,10 @@
+export default interface VocalProfileDTO {
+    id: number;
+    profileImage: string;
+    name: string;
+    contact: string;
+    category: string[];
+    keyword: string[];
+    introduce: string;
+    isSelected: boolean;
+};

--- a/src/domain/profile/interfaces/VocalProfileGetDTO.ts
+++ b/src/domain/profile/interfaces/VocalProfileGetDTO.ts
@@ -1,0 +1,4 @@
+export default interface VocalProfileGetDTO {
+    tableName: string;
+    userId: string;
+};

--- a/src/domain/profile/interfaces/VocalProfileGetReturnDTO.ts
+++ b/src/domain/profile/interfaces/VocalProfileGetReturnDTO.ts
@@ -1,0 +1,9 @@
+import PortfolioDTO from './PortfolioDTO';
+import ProfileDTO from './VocalProfileDTO';
+
+export default interface VocalProfileGetReturnDTO {
+    whoamI: string;
+    isMe: boolean;
+    vocalProfile: ProfileDTO;
+    vocalPortfolio: PortfolioDTO[];
+};

--- a/src/domain/profile/interfaces/index.ts
+++ b/src/domain/profile/interfaces/index.ts
@@ -1,8 +1,10 @@
 export { default as PortfolioDTO } from './PortfolioDTO';
-export { default as ProfileDTO } from './ProfileDTO';
+export { default as ProducerProfileDTO } from './ProducerProfileDTO';
+export { default as VocalProfileDTO } from './VocalProfileDTO';
 export { default as ProducerProfileGetDTO } from './ProducerProfileGetDTO';
 export { default as ProducerProfileGetReturnDTO } from './ProducerProfileGetReturnDTO';
 export { default as VocalProfileGetDTO } from './VocalProfileGetDTO';
+export { default as VocalProfileGetReturnDTO } from './VocalProfileGetReturnDTO';
 export { default as ProducerProfileUpdateDTO } from './ProducerProfileUpdateDTO';
 export { default as ProducerProfileUpdateReturnDTO } from './VocalProfileUpdateReturnDTO';
 export { default as VocalProfileUpdateDTO } from './VocalProfileUpdateDTO';

--- a/src/domain/profile/interfaces/index.ts
+++ b/src/domain/profile/interfaces/index.ts
@@ -1,3 +1,9 @@
+export { default as PortfolioDTO } from './PortfolioDTO';
+export { default as ProfileDTO } from './ProfileDTO';
+export { default as ProducerProfileGetDTO } from './ProducerProfileGetDTO';
+export { default as ProducerProfileGetReturnDTO } from './ProducerProfileGetReturnDTO';
+export { default as VocalProfileGetDTO } from './VocalProfileGetDTO';
 export { default as ProducerProfileUpdateDTO } from './ProducerProfileUpdateDTO';
 export { default as ProducerProfileUpdateReturnDTO } from './VocalProfileUpdateReturnDTO';
 export { default as VocalProfileUpdateDTO } from './VocalProfileUpdateDTO';
+export { default as VocalProfileUpdateReturnDTO } from './VocalProfileUpdateReturnDTO';

--- a/src/domain/profile/repository/findProducerProfileByUserId.ts
+++ b/src/domain/profile/repository/findProducerProfileByUserId.ts
@@ -1,0 +1,72 @@
+import { InvalidProducer, GetProducerInfoFail } from './../../../global/middlewares/error/errorInstance';
+import config from '../../../global/config';
+import prisma from '../../../global/config/prismaClient';
+import { PortfolioDTO, ProfileDTO } from '../interfaces';
+import { rm } from '../../../global/constants';
+import { getS3OneBeatObject, getS3OneImageObject } from '../../../global/modules/S3Object/get';
+
+function objectParams_url(bucketName: string, fileKey: string) {
+    return {
+        Bucket: bucketName,
+        Key: fileKey,
+    };
+};
+
+const findProducerProfileById = async(producerId: number, limit: number, page: number) => {
+    try {
+        const data = await prisma.producer
+            .findUnique({
+                select: {
+                    id: true, producerImage: true, name: true, contact: true, category: true, keyword: true, introduce: true,
+                    ProducerPortfolio: {
+                        select: { id: true, portfolioFile: true, portfolioImage: true, title: true, content: true, keyword: true, category: true, duration: true },
+                        orderBy: { isTitle: 'desc' },
+                    },
+                },
+                where: { id: producerId },
+            })
+            .then(async (producer) => {
+                if (!producer) throw new InvalidProducer(rm.INVALID_PRODUCER);
+
+                const profileImage = (producer.producerImage === config.defaultUserProfileImage) ?
+                                        config.defaultUserProfileImage : await getS3OneImageObject(objectParams_url(config.profileImageBucketName, producer.producerImage));
+
+                const profileDTO: ProfileDTO = {
+                    id: producer.id,
+                    profileImage: profileImage as string,
+                    name: producer.name,
+                    contact: producer.contact as string,
+                    category: producer.category,
+                    keyword: producer.keyword,
+                    introduce: producer.introduce as string,
+                };
+
+                const portfolioList = await Promise.all(producer.ProducerPortfolio.map(async (portfolio) => {
+                    const beatURL = await getS3OneBeatObject(objectParams_url(config.producerPortfolioBucketName, portfolio.portfolioFile));
+                    const imageURL = (portfolio.portfolioImage === config.defaultJacketAndProducerPortfolioImage) ? 
+                                        portfolio.portfolioImage : 
+                                        await getS3OneImageObject(objectParams_url(config.producerPortfolioBucketName, portfolio.portfolioImage));
+
+                    const portfolioDTO: PortfolioDTO = {
+                        id: portfolio.id,
+                        jacketImage: imageURL as string,
+                        beatWavFile: beatURL as string,
+                        title: portfolio.title,
+                        content: portfolio.content as string,
+                        keyword: portfolio.keyword,
+                        category: portfolio.category[0] as string,
+                        wavFileLength: portfolio.duration,
+                    }
+                    return portfolioDTO;
+                }));
+
+                return { profileDTO, portfolioList };
+            });
+
+        return data;
+    } catch (error) {
+        throw error;
+    }
+};
+
+export default findProducerProfileById;

--- a/src/domain/profile/repository/findProducerTitleByUserIdAsPortfolioDTO.ts
+++ b/src/domain/profile/repository/findProducerTitleByUserIdAsPortfolioDTO.ts
@@ -1,0 +1,49 @@
+import { InvalidProducerTitlePortfolio } from './../../../global/middlewares/error/errorInstance/mypage/InvalidProducerTitlePortfolio';
+import prisma from '../../../global/config/prismaClient';
+import { PortfolioDTO } from '../interfaces';
+import { rm } from '../../../global/constants';
+import { getS3OneBeatObject, getS3OneImageObject } from '../../../global/modules/S3Object/get';
+import config from '../../../global/config';
+
+function objectParams_url(bucketName: string, fileKey: string) {
+    return {
+        Bucket: bucketName,
+        Key: fileKey,
+    };
+};
+
+const findProducerTitleByUserIdAsPortfolioDTO = async(userId: number) => {
+    try {
+        const data = await prisma.producerPortfolio
+            .findFirst({
+                where: { producerId: userId, isTitle: true },
+            })
+            .then(async (title) => {
+                if (!title) throw new InvalidProducerTitlePortfolio(rm.INVALID_USER_TITLE);
+
+                const beatURL = await getS3OneBeatObject(objectParams_url(config.producerPortfolioBucketName, title.portfolioFile));
+                const imageURL = (title.portfolioImage === config.defaultJacketAndProducerPortfolioImage) ? 
+                                    title.portfolioImage : 
+                                    await getS3OneImageObject(objectParams_url(config.producerPortfolioBucketName, title.portfolioImage));
+
+                const portfolioDTO: PortfolioDTO = {
+                    id: title.id,
+                    jacketImage: imageURL as string,
+                    beatWavFile: beatURL as string,
+                    title: title.title,
+                    content: title.content as string,
+                    keyword: title.keyword,
+                    category: title.category[0] as string,
+                    wavFileLength: title.duration,
+                };
+
+                return portfolioDTO;
+            });
+
+        return data;
+    } catch(error) {
+        throw error;
+    }
+};
+
+export default findProducerTitleByUserIdAsPortfolioDTO;

--- a/src/domain/profile/repository/findVocalProfileByUserId.ts
+++ b/src/domain/profile/repository/findVocalProfileByUserId.ts
@@ -1,0 +1,79 @@
+import { InvalidVocal } from '../../../global/middlewares/error/errorInstance';
+import config from '../../../global/config';
+import prisma from '../../../global/config/prismaClient';
+import { PortfolioDTO, VocalProfileDTO } from '../interfaces';
+import { rm } from '../../../global/constants';
+import { getS3OneBeatObject, getS3OneImageObject } from '../../../global/modules/S3Object/get';
+import { vocalTitleAsPortfolioDTO } from '.';
+
+function objectParams_url(bucketName: string, fileKey: string) {
+    return {
+        Bucket: bucketName,
+        Key: fileKey,
+    };
+};
+
+const findVocalProfileById = async(vocalId: number, limit: number, page: number) => {
+    try {
+        const data = await prisma.vocal
+            .findUnique({
+                select: {
+                    id: true, vocalImage: true, name: true, contact: true, category: true, keyword: true, introduce: true, isSelected: true,
+                    VocalPortfolio: {
+                        select: { id: true, portfolioFile: true, portfolioImage: true, title: true, content: true, keyword: true, category: true, duration: true },
+                        orderBy: { createdAt: 'desc' },
+                        where: { isTitle: false },
+                        skip: (page-1)*limit,
+                        take: limit,
+                    },
+                },
+                where: { id: vocalId },
+            })
+            .then(async (vocal) => {
+                if (!vocal) throw new InvalidVocal(rm.INVALID_VOCAL);
+
+                const profileImage = (vocal.vocalImage === config.defaultUserProfileImage) ?
+                                        config.defaultUserProfileImage : await getS3OneImageObject(objectParams_url(config.profileImageBucketName, vocal.vocalImage));
+
+                const profileDTO: VocalProfileDTO = {
+                    id: vocal.id,
+                    profileImage: profileImage as string,
+                    name: vocal.name,
+                    contact: vocal.contact as string,
+                    category: vocal.category,
+                    keyword: vocal.keyword,
+                    introduce: vocal.introduce as string,
+                    isSelected: vocal.isSelected,
+                };
+
+                const portfolioList = await Promise.all(vocal.VocalPortfolio.map(async (portfolio) => {
+                    const beatURL = await getS3OneBeatObject(objectParams_url(config.vocalPortfolioBucketName, portfolio.portfolioFile));
+                    const imageURL = (portfolio.portfolioImage === config.defaultVocalPortfolioImage) ? 
+                                        portfolio.portfolioImage : 
+                                        await getS3OneImageObject(objectParams_url(config.vocalPortfolioBucketName, portfolio.portfolioImage));
+
+                    const portfolioDTO: PortfolioDTO = {
+                        id: portfolio.id,
+                        jacketImage: imageURL as string,
+                        beatWavFile: beatURL as string,
+                        title: portfolio.title,
+                        content: portfolio.content as string,
+                        keyword: portfolio.keyword,
+                        category: portfolio.category[0] as string,
+                        wavFileLength: portfolio.duration,
+                    }
+                    return portfolioDTO;
+                }));
+
+                portfolioList.unshift(await vocalTitleAsPortfolioDTO(vocalId));  //! 포트폴리오배열 [0]에 타이틀 넣기 
+
+                return { profileDTO, portfolioList };
+            });
+
+        return data;
+    } catch (error) {
+        throw error;
+    }
+};
+
+export default findVocalProfileById;

--- a/src/domain/profile/repository/findVocalTitleByUserIdAsPortfolioDTO.ts
+++ b/src/domain/profile/repository/findVocalTitleByUserIdAsPortfolioDTO.ts
@@ -1,0 +1,49 @@
+import prisma from '../../../global/config/prismaClient';
+import { PortfolioDTO } from '../interfaces';
+import { rm } from '../../../global/constants';
+import { getS3OneBeatObject, getS3OneImageObject } from '../../../global/modules/S3Object/get';
+import config from '../../../global/config';
+import { InvalidVocalTitlePortfolio } from '../../../global/middlewares/error/errorInstance';
+
+function objectParams_url(bucketName: string, fileKey: string) {
+    return {
+        Bucket: bucketName,
+        Key: fileKey,
+    };
+};
+
+const findVocalTitleByUserIdAsPortfolioDTO = async(userId: number) => {
+    try {
+        const data = await prisma.vocalPortfolio
+            .findFirst({
+                where: { vocalId: userId, isTitle: true },
+            })
+            .then(async (title) => {
+                if (!title) throw new InvalidVocalTitlePortfolio(rm.INVALID_USER_TITLE);
+
+                const beatURL = await getS3OneBeatObject(objectParams_url(config.vocalPortfolioBucketName, title.portfolioFile));
+                const imageURL = (title.portfolioImage === config.defaultVocalPortfolioImage) ? 
+                                    title.portfolioImage : 
+                                    await getS3OneImageObject(objectParams_url(config.vocalPortfolioBucketName, title.portfolioImage));
+
+                const portfolioDTO: PortfolioDTO = {
+                    id: title.id,
+                    jacketImage: imageURL as string,
+                    beatWavFile: beatURL as string,
+                    title: title.title,
+                    content: title.content as string,
+                    keyword: title.keyword,
+                    category: title.category[0] as string,
+                    wavFileLength: title.duration,
+                };
+
+                return portfolioDTO;
+            });
+
+        return data;
+    } catch(error) {
+        throw error;
+    }
+};
+
+export default findVocalTitleByUserIdAsPortfolioDTO;

--- a/src/domain/profile/repository/index.ts
+++ b/src/domain/profile/repository/index.ts
@@ -1,2 +1,3 @@
+export { default as getProducerProfileById } from './findProducerProfileByUserId';
 export { default as updateProducerProfileByUserId } from './updateProducerProfileByUserId';
 export { default as updateVocalProfileByUserId } from './updateVocalProfileByUserId';

--- a/src/domain/profile/repository/index.ts
+++ b/src/domain/profile/repository/index.ts
@@ -1,3 +1,6 @@
 export { default as getProducerProfileById } from './findProducerProfileByUserId';
+export { default as getVocalProfileById } from './findVocalProfileByUserId';
 export { default as updateProducerProfileByUserId } from './updateProducerProfileByUserId';
 export { default as updateVocalProfileByUserId } from './updateVocalProfileByUserId';
+export { default as producerTitleAsPortfolioDTO } from './findProducerTitleByUserIdAsPortfolioDTO';
+export { default as vocalTitleAsPortfolioDTO } from './findVocalTitleByUserIdAsPortfolioDTO';

--- a/src/domain/profile/repository/updateVocalProfileByUserId.ts
+++ b/src/domain/profile/repository/updateVocalProfileByUserId.ts
@@ -1,9 +1,8 @@
-import { ProducerProfileUpdateDTO, ProducerProfileUpdateReturnDTO, VocalProfileUpdateDTO } from '../interfaces';
+import { VocalProfileUpdateReturnDTO, VocalProfileUpdateDTO } from '../interfaces';
 import prisma from '../../../global/config/prismaClient';
 import convertCategory from '../../../global/modules/convertCategory';
 import config from '../../../global/config';
 import { getS3OneImageObject } from '../../../global/modules/S3Object/get';
-import VocalProfileUpdateReturnDTO from '../interfaces/VocalProfileUpdateReturnDTO';
 
 function objectParams_url(imageKey: string) {
     return {

--- a/src/domain/profile/router/ProducerRouter.ts
+++ b/src/domain/profile/router/ProducerRouter.ts
@@ -1,13 +1,17 @@
 import { Router } from "express";
-import { authJWT, authMulterJWT, s3UploadeMiddleware } from '../../../global/middlewares';
+import { authJWT, authMulterJWT, checkPaginationValue, s3UploadeMiddleware } from '../../../global/middlewares';
 import ProducerController from '../controller/ProducerController';
 
 const router: Router = Router();
 
+router.get('/:producerId',
+            checkPaginationValue,
+            authJWT,
+            ProducerController.getProducerProfile);
+
 router.patch('/',
             authMulterJWT,
             s3UploadeMiddleware.uploadS3ProfileImageFile('producer'),
-            ProducerController.updateProducerProfile,
-);
+            ProducerController.updateProducerProfile);
 
 export default router;

--- a/src/domain/profile/router/VocalRouter.ts
+++ b/src/domain/profile/router/VocalRouter.ts
@@ -7,7 +7,6 @@ const router: Router = Router();
 router.patch('/',
             authMulterJWT,
             s3UploadeMiddleware.uploadS3ProfileImageFile('vocal'),
-            VocalController.updateVocalProfile,
-);
+            VocalController.updateVocalProfile);
 
 export default router;

--- a/src/domain/profile/router/VocalRouter.ts
+++ b/src/domain/profile/router/VocalRouter.ts
@@ -1,8 +1,13 @@
 import { Router } from "express";
-import { authJWT, authMulterJWT, s3UploadeMiddleware } from '../../../global/middlewares';
+import { authJWT, authMulterJWT, checkPaginationValue, s3UploadeMiddleware } from '../../../global/middlewares';
 import VocalController from '../controller/VocalController';
 
 const router: Router = Router();
+
+router.get('/:vocalId',
+            checkPaginationValue,
+            authJWT,
+            VocalController.getVocalProfile);
 
 router.patch('/',
             authMulterJWT,

--- a/src/domain/profile/service/ProducerService.ts
+++ b/src/domain/profile/service/ProducerService.ts
@@ -1,12 +1,30 @@
-import config from '../../../global/config';
 import { rm } from '../../../global/constants';
-import { UpdateProducerProfileFail } from '../../../global/middlewares/error/errorInstance';
+import { GetProducerInfoFail, UpdateProducerProfileFail } from '../../../global/middlewares/error/errorInstance';
 import updateS3ProfileImage from '../../../global/modules/S3Object/update/updateOneProfileImage';
 import { getUserById } from '../../user/repository';
-import { ProducerProfileUpdateDTO, ProducerProfileUpdateReturnDTO } from '../interfaces';
-import { updateProducerProfileByUserId } from '../repository';
+import { ProducerProfileGetDTO, ProducerProfileGetReturnDTO, ProducerProfileUpdateDTO } from '../interfaces';
+import { getProducerProfileById, updateProducerProfileByUserId } from '../repository';
 
-const updateProducerProfile = async(profileDTO: ProducerProfileUpdateDTO, tableName: string, userId: number, imageFileKey: string) => {
+const getProducerProfile = async (profileDTO: ProducerProfileGetDTO, producerId: number, page: number, limit: number) => {
+    try {
+        const isMe = (profileDTO.tableName === 'producer' && producerId === Number(profileDTO.userId)) ? true : false;
+        
+        const data = await getProducerProfileById(producerId, page, limit);
+        if (!data) throw new GetProducerInfoFail(rm.GET_USER_INFORMATION_FAIL);
+
+        const result: ProducerProfileGetReturnDTO = {
+            whoamI: profileDTO.tableName,
+            isMe: isMe,
+            producerProfile: data.profileDTO,
+            producerPortfolio: data.portfolioList,
+        };
+        return result;
+    } catch (error) {
+        throw error;
+    }
+};
+
+const updateProducerProfile = async (profileDTO: ProducerProfileUpdateDTO, tableName: string, userId: number, imageFileKey: string) => {
     try {
         const user = await getUserById.producer(userId);
         await updateS3ProfileImage(user?.producerImage as string);
@@ -18,10 +36,10 @@ const updateProducerProfile = async(profileDTO: ProducerProfileUpdateDTO, tableN
     } catch (error) {
         throw error;
     }
-}
-
+};
 
 const ProducerService = {
+    getProducerProfile,
     updateProducerProfile,
 };
 

--- a/src/domain/profile/service/ProducerService.ts
+++ b/src/domain/profile/service/ProducerService.ts
@@ -9,7 +9,7 @@ const getProducerProfile = async (profileDTO: ProducerProfileGetDTO, producerId:
     try {
         const isMe = (profileDTO.tableName === 'producer' && producerId === Number(profileDTO.userId)) ? true : false;
         
-        const data = await getProducerProfileById(producerId, page, limit);
+        const data = await getProducerProfileById(producerId, limit, page);
         if (!data) throw new GetProducerInfoFail(rm.GET_USER_INFORMATION_FAIL);
 
         const result: ProducerProfileGetReturnDTO = {

--- a/src/domain/profile/service/VocalService.ts
+++ b/src/domain/profile/service/VocalService.ts
@@ -1,9 +1,28 @@
 import { rm } from '../../../global/constants';
-import { UpdateVocalProfileFail } from '../../../global/middlewares/error/errorInstance';
+import { GetVocalInfoFail, UpdateVocalProfileFail } from '../../../global/middlewares/error/errorInstance';
 import updateS3ProfileImage from '../../../global/modules/S3Object/update/updateOneProfileImage';
 import { getUserById } from '../../user/repository';
-import { VocalProfileUpdateDTO } from '../interfaces';
-import { updateVocalProfileByUserId } from '../repository';
+import { VocalProfileGetDTO, VocalProfileGetReturnDTO, VocalProfileUpdateDTO } from '../interfaces';
+import { getVocalProfileById, updateVocalProfileByUserId } from '../repository';
+
+const getVocalProfile = async (profileDTO: VocalProfileGetDTO, vocalId: number, page: number, limit: number) => {
+    try {
+        const isMe = (profileDTO.tableName === 'vocal' && vocalId === Number(profileDTO.userId)) ? true : false;
+        
+        const data = await getVocalProfileById(vocalId, limit, page);
+        if (!data) throw new GetVocalInfoFail(rm.GET_USER_INFORMATION_FAIL);
+
+        const result: VocalProfileGetReturnDTO = {
+            whoamI: profileDTO.tableName,
+            isMe: isMe,
+            vocalProfile: data.profileDTO,
+            vocalPortfolio: data.portfolioList,
+        };
+        return result;
+    } catch (error) {
+        throw error;
+    }
+};
 
 const updateVocalProfile = async(profileDTO: VocalProfileUpdateDTO, tableName: string, userId: number, imageFileKey: string) => {
     try {
@@ -17,10 +36,10 @@ const updateVocalProfile = async(profileDTO: VocalProfileUpdateDTO, tableName: s
     } catch (error) {
         throw error;
     }
-}
-
+};
 
 const VocalService = {
+    getVocalProfile,
     updateVocalProfile,
 };
 

--- a/src/domain/tracks/repository/findBeatsByCateg.ts
+++ b/src/domain/tracks/repository/findBeatsByCateg.ts
@@ -47,13 +47,13 @@ const findBeatsByCateg = async(page: number, limit: number, categ: string[]) => 
                     return await Promise.all(trackList.map(async (track) => {
                         const beatURL = await getS3OneBeatObject(objectParams_url(track.beatFile));
                         const imageURL = (track.beatImage === config.defaultJacketAndProducerPortfolioImage) ? 
-                                            track.beatImage : await getS3OneImageObject(track.beatImage);
+                                            track.beatImage : await getS3OneImageObject(objectParams_url(track.beatImage));
             
                         const returnDTO: GetBeatReturnDTO = {
                             beatId: track.id,
-                            jacketImage: track.beatImage,
+                            jacketImage: imageURL as string,
                             wavFile: beatURL as string,
-                            title: imageURL as string,
+                            title: track.title,
                             producerId: track.Producer.id,
                             producerName: track.Producer.name,
                             keyword: track.keyword,

--- a/src/global/constants/responseMessage.ts
+++ b/src/global/constants/responseMessage.ts
@@ -113,6 +113,12 @@ export default {
     INVALID_USER_TITLE: "유효하지 않은 사용자의 타이틀",
 
     // 프로필 관련
+    GET_USER_INFORMATION_SUCCESS: "유저관련 정보 조회 성공",
+    GET_USER_INFORMATION_FAIL: "유저관련 정보 조회 실패",
+    GET_PRODUCER_PROFILE_SUCCESS: "프로듀서 프로필 조회 성공",
+    GET_PRODUCER_PROFILE_FAIL: "프로듀서 프로필 조회 실패",
+    GET_VOCAL_PROFILE_SUCCESS: "보컬 프로필 조회 성공",
+    GET_VOCAL_PROFILE_FAIL: "보컬 프로필 조회 실패",
     UPDATE_PRODUCER_PROFILE_SUCCESS: "프로듀서 프로필 수정 성공",
     UPDATE_PRODUCER_PROFILE_FAIL: "프로듀서 프로필 수정 실패",
     UPDATE_VOCAL_PROFILE_SUCCESS: "보컬 프로필 수정 성공",
@@ -125,6 +131,8 @@ export default {
     UPDATE_VOCAL_NEW_TITLE_FAIL: "보컬 타이틀이 될 포트폴리오 변경 실패",
     UPDATE_VOCAL_TITLE_SUCCESS: "보컬 타이틀 수정 성공",
     UPDATE_VOCAL_TITLE_FAIL: "보컬 타이틀 수정 실패",
+    INVALID_PRODUCER: "유효하지 않은 프로듀서",
+    INVALID_VOCAL: "유효하지 않은 보컬",
 
     // 보컬검색 관련
     GET_VOCAL_LIST_SUCCESS: "보컬 필터링 검색 성공",

--- a/src/global/middlewares/error/errorInstance/index.ts
+++ b/src/global/middlewares/error/errorInstance/index.ts
@@ -78,6 +78,10 @@ export {
     UpdateProducerProfileFail,
     UpdateVocalProfileFail,
     GetImageFail,
+    GetProducerInfoFail,
+    GetVocalInfoFail,
+    InvalidProducer,
+    InvalidVocal,
 } from './profile';
 
 export {

--- a/src/global/middlewares/error/errorInstance/profile/GetProducerInfoFail.ts
+++ b/src/global/middlewares/error/errorInstance/profile/GetProducerInfoFail.ts
@@ -1,0 +1,12 @@
+import { sc } from '../../../../constants';
+import { AbstractError } from '../../abstractError';
+
+export class GetProducerInfoFail extends AbstractError {
+    constructor(...args: any) {
+        super(...args);
+        this.code = '1007';
+        this.name = 'Get_Producer_Info_Fail';
+        this.stack = `${this.message}\n${new Error().stack}`;
+        this.statusCode = sc.INTERNAL_SERVER_ERROR;
+    };
+};

--- a/src/global/middlewares/error/errorInstance/profile/GetVocalInfoFail.ts
+++ b/src/global/middlewares/error/errorInstance/profile/GetVocalInfoFail.ts
@@ -1,0 +1,12 @@
+import { sc } from '../../../../constants';
+import { AbstractError } from '../../abstractError';
+
+export class GetVocalInfoFail extends AbstractError {
+    constructor(...args: any) {
+        super(...args);
+        this.code = '1007';
+        this.name = 'Get_Vocal_Info_Fail';
+        this.stack = `${this.message}\n${new Error().stack}`;
+        this.statusCode = sc.INTERNAL_SERVER_ERROR;
+    };
+};

--- a/src/global/middlewares/error/errorInstance/profile/InvalidProducer.ts
+++ b/src/global/middlewares/error/errorInstance/profile/InvalidProducer.ts
@@ -1,0 +1,12 @@
+import { sc } from '../../../../constants';
+import { AbstractError } from '../../abstractError';
+
+export class InvalidProducer extends AbstractError {
+    constructor(...args: any) {
+        super(...args);
+        this.code = '1007';
+        this.name = 'Invalid_Producer';
+        this.stack = `${this.message}\n${new Error().stack}`;
+        this.statusCode = sc.BAD_REQUEST;
+    };
+};

--- a/src/global/middlewares/error/errorInstance/profile/InvalidVocal.ts
+++ b/src/global/middlewares/error/errorInstance/profile/InvalidVocal.ts
@@ -1,0 +1,12 @@
+import { sc } from '../../../../constants';
+import { AbstractError } from '../../abstractError';
+
+export class InvalidVocal extends AbstractError {
+    constructor(...args: any) {
+        super(...args);
+        this.code = '1007';
+        this.name = 'Invalid_Vocal';
+        this.stack = `${this.message}\n${new Error().stack}`;
+        this.statusCode = sc.BAD_REQUEST;
+    };
+};

--- a/src/global/middlewares/error/errorInstance/profile/index.ts
+++ b/src/global/middlewares/error/errorInstance/profile/index.ts
@@ -1,3 +1,7 @@
 export { UpdateProducerProfileFail } from './UpdateProducerProfileFail';
 export { UpdateVocalProfileFail } from './UpdateVocalProfileFail';
 export { GetImageFail } from './GetImageFail';
+export { GetProducerInfoFail } from './GetProducerInfoFail';
+export { GetVocalInfoFail } from './GetVocalInfoFail';
+export { InvalidProducer } from './InvalidProducer';
+export { InvalidVocal } from './InvalidVocal';


### PR DESCRIPTION
## 개요
- [GET]
- /profile/producer/:producerId?page=&limit=
- /profile/vocal/:vocalId?page=&limit=

## 작업사항
- 프로듀서, 보컬 프로필/포트폴리오 조회 기능 추가
- 포트폴리오[0] -> 타이틀 
- 포트폴리오[1] ~ ... -> 페이지네이션 해서 반환
